### PR TITLE
fixed typo: rest to reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A git tool with a easy terminal interface.
 
 - [x] git status
 - [x] git add [files]
-- [x] git rest -- [files]
+- [x] git reset -- [files]
 - [x] git commit [files]
 - [x] git log
 - [x] git reset <commit>
@@ -26,4 +26,3 @@ $ git-commander
 # License
 
 MIT
-


### PR DESCRIPTION
There is no `rest` command in Git, maybe it is typo of "reset"
